### PR TITLE
Implementing deployment-suggestion

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,7 @@
 {
-  "extends": "springworks/babel"
+  "extends": "springworks/babel",
+  "rules": {
+    "no-console": 0,
+    "no-process-exit": 0
+  }
 }

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,5 +1,6 @@
 instrumentation:
     include-all-sources: true
+    root: ./src
 
 reporting:
     print: summary

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "iojs"
+- '0.12'
+- iojs
 script:
-  - npm run lint
-  - npm test
+- npm run lint
+- npm test
 after_success:
-  - npm run coveralls
+- npm run coveralls
 notifications:
   email: false
+  slack:
+    secure: aX0oEq3Wqzkl8z5Z9Z0rYuHC+zCCkynAuip4bErlG5hf6gfScgUrYOv5DfE/pY3kajNBlPGk6aqlrajzJ3J0ZmrRqdI17h4MyG17/bmAmgYK+WQhaIrdxXL/+GW1lECJuxXja/L6IPq7je6lVBlxncmIlp/OqcTVlHDmC2idlQ8lMJskwF//k8hkA8NKBikQzisAaNH3qKCtSGLQyMqYHFD/U07wGfhS55cEUQp/mxYLTaEH85eTAoez/Am7uuvAsqli4TCK5Vj7v0pk5lrbC4+9q2aunlzi66IhR54YOLjMj3nogkaOoYEZNOr5HIq6YfXL33i2H67HvCS4uojZjmfagX/V2A1JHam7BTGqJGpaWHmRBCFSIq85o3myGCsN3lGactQkUpIVGxbRCviLbanfZRiTv8ld60JmAdVNqKgbCw5of2wshQtObN98Xnej9V+8+BNN3kAULlAUd3TMj+4JbNlFf2T5CEktR8qtwUjbxgr4/5RMRWpQgAFdRbnF9wtWr80Z+0sQbhHkI+dBBzKHEze1Z1+0O07EBTlD3H2GBlDD6HcBxZ9G/7kbLZvEnxya65wnAvQ5BT0xw7e9bNxnXCSwpYqEES2SvqYUd0IqadFlZucuiM6HtxzUCRVzphZoUgt4qAODgn7XQKvf6YLx7vEnJkptZUAduraNUj0=
 sudo: false

--- a/README.md
+++ b/README.md
@@ -3,9 +3,42 @@
 [![Build Status](https://travis-ci.org/Springworks/node-deployment-notifier.png?branch=master)](https://travis-ci.org/Springworks/node-deployment-notifier)
 [![Coverage Status](https://coveralls.io/repos/Springworks/node-deployment-notifier/badge.png?branch=master)](https://coveralls.io/r/Springworks/node-deployment-notifier?branch=master)
 
-Includes changelog, new version number.
+## Environment variables
+
+- `NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL`: URL to the Slack webhook
+- `NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL`: Slack channel name to post messages to, e.g. `#deployments`
+- `NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME`: Username to use when posting, e.g. `Row Bot`
+
+## Usage
+
+Install module globally:
+
+```
+npm install -g deployment-notifier
+```
+
+### Suggest deployment
+Sends Slack notification with a suggestion to make a deployment.
+
+Includes changelog (since last deployment).
+
+**Usage**
+```
+  Usage: deployment-suggestion [options]
+
+  Options:
+
+    -h, --help                 output usage information
+    -N, --app-name <app name>  Application name
+    -T, --tag-name <git tag>   Name of tag marking latest deployment
+```
+
+**Example**
+
+```
+$ deployment-suggestion --app-name "some app" --tag-name v1.0.0 
+```
 
 ## License
 
 MIT
-

--- a/bin/deployment-suggestion.js
+++ b/bin/deployment-suggestion.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+require('babel/polyfill');
+
+var deployment_notifier = require('../lib/cli/suggest-deployment');
+deployment_notifier.run(process);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Sends notifications about deployments for a Git repo",
   "private": false,
   "license": "MIT",
+  "main": "./lib/index.js",
   "scripts": {
     "prepublish": "npm run build",
     "build": "rm -rf lib && babel src --out-dir lib",
@@ -11,7 +12,9 @@
     "lint": "eslint .",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
-  "bin": {},
+  "bin": {
+    "deployment-suggestion": "./bin/deployment-suggestion.js"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/Springworks/node-deployment-notifier.git"
@@ -21,9 +24,12 @@
     "url": "https://github.com/Springworks/node-deployment-notifier/issues"
   },
   "dependencies": {
+    "commander": "^2.9.0",
+    "node-slack": "0.0.7",
+    "babel": "^5.8.23"
   },
   "devDependencies": {
-    "@springworks/test-harness": "1.0.3",
+    "@springworks/test-harness": "1.2.0",
     "babel-eslint": "^4.1.2",
     "coveralls": "^2.11.4",
     "eslint": "1.5.1",
@@ -31,7 +37,6 @@
     "eslint-plugin-mocha": "1.0.0",
     "eslint-plugin-should-promised": "^1.0.5",
     "istanbul": "^0.3.21",
-    "babel": "^5.8.23",
     "mocha": "^2.3.3"
   }
 }

--- a/src/cli/suggest-deployment.js
+++ b/src/cli/suggest-deployment.js
@@ -1,0 +1,24 @@
+const program = require('commander');
+const deployment_notifier = require('../index');
+
+exports.run = function(process) {
+  program
+      .option('-N, --app-name <app name>', 'Application name')
+      .option('-T, --latest-deployment-tag <git tag>', 'Name of tag for latest deployment')
+      .parse(process.argv);
+
+  console.log('');
+  console.log('Suggesting deployment for %j in app %j', program.tagName, program.appName);
+  console.log('');
+
+  const notifier = deployment_notifier.create(process.env);
+  notifier.suggestDeployment(program.appName, program.tagName)
+      .then(() => {
+        console.log('Done!');
+        process.exit(0);
+      })
+      .catch(err => {
+        console.error('Error suggesting deployment', err);
+        process.exit(1);
+      });
+};

--- a/src/configurator.js
+++ b/src/configurator.js
@@ -1,0 +1,11 @@
+exports.create = env => {
+  if (!env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL || !env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME || !env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL) {
+    throw new Error('Missing environment variables to config');
+  }
+
+  return {
+    slack_webhook_url: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL,
+    slack_username: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME,
+    slack_channel: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL,
+  };
+};

--- a/src/deployment-advisor.js
+++ b/src/deployment-advisor.js
@@ -2,12 +2,12 @@ const internals = {};
 
 exports.create = function(git_service, slack_notifier) {
   return {
-    suggestDeployment: internals.suggestDeployment.bind(null, git_service, slack_notifier),
+    suggestDeployment: internals.suggestDeployment.bind(null, { git_service, slack_notifier }),
   };
 };
 
 
-internals.suggestDeployment = function(git_service, slack_notifier, app_name, latest_tag_name) {
+internals.suggestDeployment = function({ git_service, slack_notifier }, app_name, latest_tag_name) {
   return git_service
       .getChangesSinceTag(latest_tag_name)
       .then(changelog => {

--- a/src/deployment-advisor.js
+++ b/src/deployment-advisor.js
@@ -1,0 +1,46 @@
+const internals = {};
+
+exports.create = function(git_service, slack_notifier) {
+  return {
+    suggestDeployment: internals.suggestDeployment.bind(null, git_service, slack_notifier),
+  };
+};
+
+
+internals.suggestDeployment = function(git_service, slack_notifier, app_name, latest_tag_name) {
+  return git_service
+      .getChangesSinceTag(latest_tag_name)
+      .then(changelog => {
+        return git_service
+            .getLatestAuthorName()
+            .then(last_author => {
+              const attachments = [internals.generateDeploymentSuggestionSlackAttachment(changelog)];
+              const message = `Hey, *${last_author}*. Might be a good time to deploy *${app_name}*. :rocket:`;
+              return slack_notifier.sendDeploymentMessage(message, attachments);
+            });
+      })
+      .catch(err => {
+        console.error('suggestDeployment failed', err);
+        throw err;
+      });
+};
+
+
+internals.generateDeploymentSuggestionSlackAttachment = function(changelog) {
+  return {
+    fallback: changelog,
+    fields: [
+      {
+        title: 'Changes',
+        value: changelog,
+        short: false,
+      },
+    ],
+  };
+};
+
+
+/* istanbul ignore else */
+if (process.env.NODE_ENV === 'test') {
+  exports.internals = internals;
+}

--- a/src/git/git-service.js
+++ b/src/git/git-service.js
@@ -1,0 +1,77 @@
+const internals = {};
+
+
+exports.create = function(child_process) {
+  return {
+    getChangesSinceTag: internals.getChangesSinceTag.bind(null, child_process),
+    getLatestAuthorName: internals.getLatestAuthorName.bind(null, child_process),
+  };
+};
+
+
+internals.getChangesSinceTag = function(child_process, tag_name) {
+  const git_command_args = [
+    'log',
+    '--pretty=format:"- %s"',
+    `${tag_name}..HEAD`,
+    '--no-merges',
+    '--reverse',
+  ];
+  return internals
+      .executeCommand(child_process, git_command_args)
+      .catch(err => {
+        console.error('getChangesSinceTag failed: %j', err);
+        throw err;
+      });
+};
+
+
+internals.getLatestAuthorName = function(child_process) {
+  const git_command_args = [
+    'log',
+    '--pretty=format:%an',
+    '-1',
+  ];
+  return internals
+      .executeCommand(child_process, git_command_args)
+      .catch(err => {
+        console.error('getLatestAuthorName failed: %j', err);
+        throw err;
+      });
+};
+
+
+internals.executeCommand = function(child_process, git_command_args) {
+  return new Promise((resolve, reject) => {
+    const spawned_process = child_process.spawn('git', git_command_args);
+    let stdout_str = '';
+
+    spawned_process.stdout.on('data', data => {
+      stdout_str += internals.unquotedString(data);
+    });
+
+    spawned_process.on('close', code => {
+      if (code > 0) {
+        reject(new Error(`executeCommand returned code ${code}`));
+        return;
+      }
+      resolve(stdout_str);
+    });
+
+    spawned_process.on('error', reject);
+    spawned_process.stderr.on('data', data => {
+      reject(new Error(data));
+    });
+  });
+};
+
+
+internals.unquotedString = function(str) {
+  return String(str).replace(/(^")|("$)/g, '');
+};
+
+
+/* istanbul ignore else */
+if (process.env.NODE_ENV === 'test') {
+  exports.internals = internals;
+}

--- a/src/git/git-service.js
+++ b/src/git/git-service.js
@@ -3,13 +3,13 @@ const internals = {};
 
 exports.create = function(child_process) {
   return {
-    getChangesSinceTag: internals.getChangesSinceTag.bind(null, child_process),
-    getLatestAuthorName: internals.getLatestAuthorName.bind(null, child_process),
+    getChangesSinceTag: internals.getChangesSinceTag.bind(null, { child_process }),
+    getLatestAuthorName: internals.getLatestAuthorName.bind(null, { child_process }),
   };
 };
 
 
-internals.getChangesSinceTag = function(child_process, tag_name) {
+internals.getChangesSinceTag = function({ child_process }, tag_name) {
   const git_command_args = [
     'log',
     '--pretty=format:"- %s"',
@@ -26,7 +26,7 @@ internals.getChangesSinceTag = function(child_process, tag_name) {
 };
 
 
-internals.getLatestAuthorName = function(child_process) {
+internals.getLatestAuthorName = function({ child_process }) {
   const git_command_args = [
     'log',
     '--pretty=format:%an',
@@ -41,7 +41,7 @@ internals.getLatestAuthorName = function(child_process) {
 };
 
 
-internals.executeCommand = function(child_process, git_command_args) {
+internals.executeCommand = function({ child_process }, git_command_args) {
   return new Promise((resolve, reject) => {
     const spawned_process = child_process.spawn('git', git_command_args);
     let stdout_str = '';

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,20 @@
+const child_process = require('child_process');
+
+const deployment_advisor = require('./deployment-advisor');
+const git_service = require('./git/git-service');
+const slack_notifier = require('./slack/slack-notifier');
+const configurator = require('./configurator');
+
+exports.create = function(process_env) {
+  const config = configurator.create(process_env);
+  const git_service_instance = git_service.create(child_process);
+  const slack_notifier_instance = slack_notifier.create(config.slack_webhook_url,
+      config.slack_username,
+      config.slack_channel);
+
+  const advisor = deployment_advisor.create(git_service_instance, slack_notifier_instance);
+
+  return {
+    suggestDeployment: advisor.suggestDeployment,
+  };
+};

--- a/src/slack/slack-notifier.js
+++ b/src/slack/slack-notifier.js
@@ -1,0 +1,29 @@
+const Slack = require('node-slack');
+const internals = {};
+
+exports.create = function(webhook_url, username, channel) {
+  const slack_instance = new Slack(webhook_url);
+  return {
+    sendDeploymentMessage: internals.sendDeploymentMessage.bind(null, slack_instance, username, channel),
+  };
+};
+
+
+internals.sendDeploymentMessage = function(slack_instance, username, channel, message, opt_attachments) {
+  const send_options = {
+    text: message,
+    channel,
+    username,
+    icon_emoji: ':shipit:',
+  };
+  if (Array.isArray(opt_attachments)) {
+    send_options.attachments = opt_attachments;
+  }
+  return slack_instance.send(send_options);
+};
+
+
+/* istanbul ignore else */
+if (process.env.NODE_ENV === 'test') {
+  exports.internals = internals;
+}

--- a/src/slack/slack-notifier.js
+++ b/src/slack/slack-notifier.js
@@ -4,12 +4,12 @@ const internals = {};
 exports.create = function(webhook_url, username, channel) {
   const slack_instance = new Slack(webhook_url);
   return {
-    sendDeploymentMessage: internals.sendDeploymentMessage.bind(null, slack_instance, username, channel),
+    sendDeploymentMessage: internals.sendDeploymentMessage.bind(null, { slack_instance, username, channel }),
   };
 };
 
 
-internals.sendDeploymentMessage = function(slack_instance, username, channel, message, opt_attachments) {
+internals.sendDeploymentMessage = function({ slack_instance, username, channel }, message, opt_attachments) {
   const send_options = {
     text: message,
     channel,

--- a/test/acceptance/index-test.js
+++ b/test/acceptance/index-test.js
@@ -1,0 +1,28 @@
+const index = require('../../src');
+
+describe(__filename, () => {
+
+  describe('index', () => {
+    const mock_process = {
+      env: {
+        NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL: 'http://hook.com',
+        NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME: 'Mr Bot',
+        NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL: '#deployments',
+      },
+    };
+
+    it('should export create function', () => {
+      index.should.have.keys([
+        'create',
+      ]);
+    });
+
+    it('should export public functions on create()', () => {
+      index.create(mock_process.env).should.have.keys([
+        'suggestDeployment',
+      ]);
+    });
+
+  });
+
+});

--- a/test/unit/configurator-test.js
+++ b/test/unit/configurator-test.js
@@ -1,0 +1,62 @@
+const configurator = require('../../src/configurator');
+const internals = {};
+
+describe(__filename, () => {
+
+  describe('create', () => {
+    let env;
+
+    beforeEach(() => {
+      env = internals.createValidEnvVars();
+    });
+
+    describe('with all env vars provided', () => {
+
+      it('should return configuration', () => {
+        const config = configurator.create(env);
+        config.should.eql({
+          slack_webhook_url: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL,
+          slack_username: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME,
+          slack_channel: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL,
+        });
+      });
+
+    });
+
+    describe('missing required variable', () => {
+      const required_variables = [
+        'NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL',
+        'NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME',
+        'NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL',
+      ];
+
+      required_variables.forEach(param => {
+
+        describe(`missing ${param}`, () => {
+
+          beforeEach(() => {
+            delete env[param];
+          });
+
+          it('should fail with error', () => {
+            (() => configurator.create(env)).should.throw();
+          });
+
+        });
+
+      });
+
+    });
+
+  });
+
+});
+
+internals.createValidEnvVars = function() {
+  return {
+    NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL: 'http://hook.com',
+    NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME: 'Mr Bot',
+    NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL: '#deployments',
+    OTHER_VAR: 'should be ignored',
+  };
+};

--- a/test/unit/deployment-advisor-test.js
+++ b/test/unit/deployment-advisor-test.js
@@ -1,0 +1,138 @@
+const deployment_advisor = require('../../src/deployment-advisor');
+
+describe(__filename, function() {
+  let sinon_sandbox;
+  let mock_git_service;
+  let mock_slack_notifier;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  beforeEach(function mockDependencies() {
+    mock_git_service = {
+      getChangesSinceTag() {
+      },
+      getLatestAuthorName() {
+      },
+    };
+    mock_slack_notifier = {
+      sendDeploymentMessage() {
+      },
+    };
+  });
+
+  describe('create', () => {
+
+    it('should create an instance properly', () => {
+      const advisor = deployment_advisor.create(mock_git_service, mock_slack_notifier);
+      advisor.should.have.keys(['suggestDeployment']);
+    });
+
+  });
+
+  describe('internals.suggestDeployment', () => {
+
+    describe('with valid app_name, latest_tag_name', () => {
+      const app_name = 'awe-some-app';
+      const latest_tag_name = 'v1.0.1';
+
+      describe('when dependencies succeed', () => {
+        let send_deployment_message_stub;
+
+        beforeEach(function mockChangelog() {
+          sinon_sandbox.stub(mock_git_service, 'getChangesSinceTag').returns(Promise.resolve('These are all the changes'));
+        });
+
+        beforeEach(function mockLastAuthor() {
+          sinon_sandbox.stub(mock_git_service, 'getLatestAuthorName').returns(Promise.resolve('John Doe'));
+        });
+
+        beforeEach(function mockSendMessage() {
+          send_deployment_message_stub = sinon_sandbox.stub(mock_slack_notifier, 'sendDeploymentMessage').returns(Promise.resolve(null));
+        });
+
+        it('should resolve promise', () => {
+          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name).should.be.fulfilled();
+        });
+
+        it('should send message to Slack notifier', () => {
+          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name)
+              .then(() => {
+                send_deployment_message_stub.should.have.callCount(1);
+                const message_arg = send_deployment_message_stub.getCall(0).args[0];
+                const attachments_arg = send_deployment_message_stub.getCall(0).args[1];
+
+                message_arg.should.eql('Hey, *John Doe*. Might be a good time to deploy *awe-some-app*. :rocket:');
+                attachments_arg.should.be.instanceOf(Array);
+                attachments_arg.should.have.length(1);
+              });
+        });
+
+      });
+
+      describe('when git_service fails', () => {
+
+        beforeEach(function mockChangelog() {
+          const err = new Error('Mocked getChangesSinceTag error');
+          sinon_sandbox.stub(mock_git_service, 'getChangesSinceTag').returns(Promise.reject(err));
+        });
+
+        it('should reject promise', () => {
+          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name).should.be.rejected();
+        });
+
+      });
+
+      describe('when only slack_notifier fails', () => {
+
+        beforeEach(function mockChangelog() {
+          sinon_sandbox.stub(mock_git_service, 'getChangesSinceTag').returns(Promise.resolve('These are all the changes'));
+        });
+
+        beforeEach(function mockLastAuthor() {
+          sinon_sandbox.stub(mock_git_service, 'getLatestAuthorName').returns(Promise.resolve('John Doe'));
+        });
+
+        beforeEach(function mockFailedSendMessage() {
+          const err = new Error('Mocked getChangesSinceTag error');
+          sinon_sandbox.stub(mock_slack_notifier, 'sendDeploymentMessage').returns(Promise.reject(err));
+        });
+
+        it('should reject promise', () => {
+          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name).should.be.rejected();
+        });
+
+      });
+
+    });
+
+  });
+
+  describe('internals.generateDeploymentSuggestionSlackAttachment', () => {
+
+    describe('with valid changelog', () => {
+      const changelog = '-This\n-Is\n-Changing';
+      it('should define attachment as required by Slack', () => {
+        const attachment = deployment_advisor.internals.generateDeploymentSuggestionSlackAttachment(changelog);
+        attachment.should.eql({
+          fallback: changelog,
+          fields: [
+            {
+              title: 'Changes',
+              value: changelog,
+              short: false,
+            },
+          ],
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/deployment-advisor-test.js
+++ b/test/unit/deployment-advisor-test.js
@@ -4,6 +4,7 @@ describe(__filename, function() {
   let sinon_sandbox;
   let mock_git_service;
   let mock_slack_notifier;
+  let dependencies;
 
   beforeEach(() => {
     sinon_sandbox = sinon.sandbox.create();
@@ -24,6 +25,8 @@ describe(__filename, function() {
       sendDeploymentMessage() {
       },
     };
+
+    dependencies = { git_service: mock_git_service, slack_notifier: mock_slack_notifier };
   });
 
   describe('create', () => {
@@ -57,11 +60,11 @@ describe(__filename, function() {
         });
 
         it('should resolve promise', () => {
-          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name).should.be.fulfilled();
+          return deployment_advisor.internals.suggestDeployment(dependencies, app_name, latest_tag_name).should.be.fulfilled();
         });
 
         it('should send message to Slack notifier', () => {
-          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name)
+          return deployment_advisor.internals.suggestDeployment(dependencies, app_name, latest_tag_name)
               .then(() => {
                 send_deployment_message_stub.should.have.callCount(1);
                 const message_arg = send_deployment_message_stub.getCall(0).args[0];
@@ -83,7 +86,7 @@ describe(__filename, function() {
         });
 
         it('should reject promise', () => {
-          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name).should.be.rejected();
+          return deployment_advisor.internals.suggestDeployment(dependencies, app_name, latest_tag_name).should.be.rejected();
         });
 
       });
@@ -104,7 +107,7 @@ describe(__filename, function() {
         });
 
         it('should reject promise', () => {
-          return deployment_advisor.internals.suggestDeployment(mock_git_service, mock_slack_notifier, app_name, latest_tag_name).should.be.rejected();
+          return deployment_advisor.internals.suggestDeployment(dependencies, app_name, latest_tag_name).should.be.rejected();
         });
 
       });

--- a/test/unit/git/git-service-test.js
+++ b/test/unit/git/git-service-test.js
@@ -1,0 +1,134 @@
+const git_service = require('../../../src/git/git-service');
+
+describe(__filename, function() {
+  const mock_child_process = {};
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('create', () => {
+
+    describe('with valid dependencies', () => {
+
+      it('should return object with public functions', () => {
+        const instance = git_service.create(mock_child_process);
+        instance.should.have.keys([
+          'getChangesSinceTag',
+          'getLatestAuthorName',
+        ]);
+      });
+
+    });
+
+  });
+
+  describe('internals.getChangesSinceTag', () => {
+
+    describe('with child_process, tag_name', () => {
+      const tag_name = 'the-tag';
+      let execute_command_stub;
+
+      describe('when exec() succeeds', () => {
+        const result_str = 'This is the change';
+
+        beforeEach(function mockSuccessfulCommand() {
+          execute_command_stub = sinon_sandbox.stub(git_service.internals, 'executeCommand').returns(Promise.resolve(result_str));
+        });
+
+        it('should resolve promise once done', () => {
+          return git_service.internals.getChangesSinceTag(mock_child_process, tag_name).should.be.fulfilledWith(result_str);
+        });
+
+        it('should invoke exec() with the correct command', () => {
+          const expected_command_args = [
+            'log',
+            '--pretty=format:"- %s"',
+            `${tag_name}..HEAD`,
+            '--no-merges',
+            '--reverse',
+          ];
+          return git_service.internals.getChangesSinceTag(mock_child_process, tag_name)
+              .then(() => {
+                execute_command_stub.should.have.callCount(1);
+
+                const command_arg = execute_command_stub.getCall(0).args[1];
+                command_arg.should.eql(expected_command_args);
+              });
+        });
+
+      });
+
+      describe('when exec() fails', () => {
+
+        beforeEach(function mockFailingExecuteCommand() {
+          const err = new Error('Mocked exec() error');
+          execute_command_stub = sinon_sandbox.stub(git_service.internals, 'executeCommand').returns(Promise.reject(err));
+        });
+
+        it('should reject promise', () => {
+          return git_service.internals.getChangesSinceTag(mock_child_process, tag_name).should.be.rejected();
+        });
+
+      });
+
+    });
+
+  });
+
+  describe('internals.getLatestAuthorName', () => {
+    describe('with child_process, tag_name', () => {
+      const tag_name = 'the-tag';
+      let execute_command_stub;
+
+      describe('when exec() succeeds', () => {
+        const result_str = 'John Doe';
+
+        beforeEach(function mockSuccessfulCommand() {
+          execute_command_stub = sinon_sandbox.stub(git_service.internals, 'executeCommand').returns(Promise.resolve(result_str));
+        });
+
+        it('should resolve promise once done', () => {
+          return git_service.internals.getLatestAuthorName(mock_child_process, tag_name).should.be.fulfilledWith(result_str);
+        });
+
+        it('should invoke exec() with the correct command', () => {
+          const expected_command_args = [
+            'log',
+            '--pretty=format:%an',
+            '-1',
+          ];
+          return git_service.internals.getLatestAuthorName(mock_child_process, tag_name)
+              .then(() => {
+                execute_command_stub.should.have.callCount(1);
+
+                const command_arg = execute_command_stub.getCall(0).args[1];
+                command_arg.should.eql(expected_command_args);
+              });
+        });
+
+      });
+
+    });
+
+  });
+
+  describe('internals.unquotedString', () => {
+
+    describe('with string surrounded by quotes, having quote in the middle', () => {
+      const str = '"foo "bar" baz"';
+
+      it('should strip quotes', () => {
+        git_service.internals.unquotedString(str).should.eql('foo "bar" baz');
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/git/git-service-test.js
+++ b/test/unit/git/git-service-test.js
@@ -42,7 +42,7 @@ describe(__filename, function() {
         });
 
         it('should resolve promise once done', () => {
-          return git_service.internals.getChangesSinceTag(mock_child_process, tag_name).should.be.fulfilledWith(result_str);
+          return git_service.internals.getChangesSinceTag({ child_process: mock_child_process }, tag_name).should.be.fulfilledWith(result_str);
         });
 
         it('should invoke exec() with the correct command', () => {
@@ -53,7 +53,7 @@ describe(__filename, function() {
             '--no-merges',
             '--reverse',
           ];
-          return git_service.internals.getChangesSinceTag(mock_child_process, tag_name)
+          return git_service.internals.getChangesSinceTag({ child_process: mock_child_process }, tag_name)
               .then(() => {
                 execute_command_stub.should.have.callCount(1);
 
@@ -72,7 +72,7 @@ describe(__filename, function() {
         });
 
         it('should reject promise', () => {
-          return git_service.internals.getChangesSinceTag(mock_child_process, tag_name).should.be.rejected();
+          return git_service.internals.getChangesSinceTag({ child_process: mock_child_process }, tag_name).should.be.rejected();
         });
 
       });
@@ -94,7 +94,7 @@ describe(__filename, function() {
         });
 
         it('should resolve promise once done', () => {
-          return git_service.internals.getLatestAuthorName(mock_child_process, tag_name).should.be.fulfilledWith(result_str);
+          return git_service.internals.getLatestAuthorName({ child_process: mock_child_process }, tag_name).should.be.fulfilledWith(result_str);
         });
 
         it('should invoke exec() with the correct command', () => {
@@ -103,7 +103,7 @@ describe(__filename, function() {
             '--pretty=format:%an',
             '-1',
           ];
-          return git_service.internals.getLatestAuthorName(mock_child_process, tag_name)
+          return git_service.internals.getLatestAuthorName({ child_process: mock_child_process }, tag_name)
               .then(() => {
                 execute_command_stub.should.have.callCount(1);
 

--- a/test/unit/slack/slack-notifier-test.js
+++ b/test/unit/slack/slack-notifier-test.js
@@ -1,0 +1,79 @@
+const slack_notifier = require('../../../src/slack/slack-notifier');
+
+describe(__filename, () => {
+  let sinon_sandbox;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('create', () => {
+
+    it('should create instance with public interface', () => {
+      const notifier = slack_notifier.create('http://webhook.url', 'username', '#channel');
+      notifier.should.have.keys([
+        'sendDeploymentMessage',
+      ]);
+    });
+
+  });
+
+  describe('internals.sendDeploymentMessage', () => {
+
+    describe('with valid params', () => {
+      let mock_slack_instance;
+      let send_message_stub;
+      let username;
+      let channel;
+      let attachments;
+      let message;
+
+      beforeEach(() => {
+        mock_slack_instance = {
+          send(msg) {
+          },
+        };
+      });
+
+      beforeEach(() => {
+        const slack_response = { res: {}, body: {} };
+        send_message_stub = sinon_sandbox.stub(mock_slack_instance, 'send').returns(Promise.resolve(slack_response));
+      });
+
+      beforeEach(() => {
+        username = 'username';
+        channel = '#channel';
+        message = 'Hello world';
+        attachments = [
+          { fallback: 'World, hello' },
+        ];
+      });
+
+      it('should resolve Promise', () => {
+        return slack_notifier.internals.sendDeploymentMessage(mock_slack_instance, username, channel, message, attachments).should.be.fulfilled();
+      });
+
+      it('should send proper message to slack instance', () => {
+        return slack_notifier.internals.sendDeploymentMessage(mock_slack_instance, username, channel, message, attachments)
+            .then(() => {
+              send_message_stub.should.have.callCount(1);
+              const send_args = send_message_stub.getCall(0).args;
+              send_args[0].should.eql({
+                text: message,
+                channel,
+                username,
+                attachments,
+                icon_emoji: ':shipit:',
+              });
+            });
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/slack/slack-notifier-test.js
+++ b/test/unit/slack/slack-notifier-test.js
@@ -54,11 +54,11 @@ describe(__filename, () => {
       });
 
       it('should resolve Promise', () => {
-        return slack_notifier.internals.sendDeploymentMessage(mock_slack_instance, username, channel, message, attachments).should.be.fulfilled();
+        return slack_notifier.internals.sendDeploymentMessage({ slack_instance: mock_slack_instance, username, channel }, message, attachments).should.be.fulfilled();
       });
 
       it('should send proper message to slack instance', () => {
-        return slack_notifier.internals.sendDeploymentMessage(mock_slack_instance, username, channel, message, attachments)
+        return slack_notifier.internals.sendDeploymentMessage({ slack_instance: mock_slack_instance, username, channel }, message, attachments)
             .then(() => {
               send_message_stub.should.have.callCount(1);
               const send_args = send_message_stub.getCall(0).args;


### PR DESCRIPTION
First feature of deployment notifier. 

`$ deployment-suggestion --app-name foo --tag-name master` will post a message to Slack, suggesting the most recent author to make a deployment.

**Possible improvements**
- Update docs to match global install
- Include link to Teamcity (probably provided as argument) to make deployment easier (suggest this is done in later PR)

---

**Example**

<img width="404" alt="skarmavbild 2015-10-14 kl 17 37 32" src="https://cloud.githubusercontent.com/assets/61638/10488715/4f233640-729a-11e5-93f9-66ebd9382731.png">

---
## Environment variables
- `NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL`: URL to the Slack webhook
- `NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL`: Slack channel name to post messages to, e.g. `#deployments`
- `NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME`: Username to use when posting, e.g. `Row Bot`
## Usage

Install module globally:

```
npm install -g deployment-notifier
```
### Suggest deployment

Sends Slack notification with a suggestion to make a deployment.

Includes changelog (since last deployment).

**Usage**

```
  Usage: deployment-suggestion [options]

  Options:

    -h, --help                 output usage information
    -N, --app-name <app name>  Application name
    -T, --tag-name <git tag>   Name of tag marking latest deployment
```

**Example**

```
$ deployment-suggestion --app-name "some app" --tag-name v1.0.0 
```
## License

MIT
