### PR TITLE
Send Slack and Webhook message after completed deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,27 @@
 [![Build Status](https://travis-ci.org/Springworks/node-deployment-notifier.png?branch=master)](https://travis-ci.org/Springworks/node-deployment-notifier)
 [![Coverage Status](https://coveralls.io/repos/Springworks/node-deployment-notifier/badge.png?branch=master)](https://coveralls.io/r/Springworks/node-deployment-notifier?branch=master)
 
+Lets you know when you should deploy and when the deployment is complete.
+
+Useful when:
+
+- You need a human to make a decision of which version to deploy (if you want to do that when committing, look at [semantic-release](https://www.npmjs.com/package/semantic-release) or similar).
+- You're using Slack
+- You have another webhook that also needs to record deployment
+
 ## Environment variables
 
+All environment variables are required.
+
+**Define to notify Slack**
 - `NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL`: URL to the Slack webhook
 - `NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL`: Slack channel name to post messages to, e.g. `#deployments`
 - `NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME`: Username to use when posting, e.g. `Row Bot`
+
+**Define for generic webhook**
+- `NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_URL`: URL to use when posting webhook with deployment info
+- `NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_USERNAME`: Basic auth username for webhook
+- `NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_PASSWORD`: Basic auth password for webhook
 
 ## Usage
 
@@ -38,6 +54,24 @@ Includes changelog (since last deployment).
 
 ```
 $ deployment-suggestion --app-name "some app" --tag-name v1.0.0 
+```
+
+### Record deployment
+Sends message after a deployment has completed, to both Slack webhook and HTTP webhook.
+
+Includes changes in the new version.
+
+**Usage**
+```
+  Usage: deployment-completed [options]
+
+  Options:
+
+    -h, --help                               output usage information
+    -N, --app-name <app name>                Application name
+    -P, --previous-deployment-tag <git tag>  Name of tag for previous deployment
+    -T, --deployment-tag <git tag>           Name of tag for latest deployment
+    -E, --environment <target environment>   The environment deployment was targeted at
 ```
 
 ## License

--- a/bin/deployment-completed.js
+++ b/bin/deployment-completed.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+require('babel/polyfill');
+
+var record_deployment = require('../lib/cli/record-deployment');
+record_deployment.run(process);

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "url": "https://github.com/Springworks/node-deployment-notifier/issues"
   },
   "dependencies": {
+    "@springworks/input-validator": "^3.1.2",
+    "babel": "^5.8.23",
     "commander": "^2.9.0",
     "node-slack": "0.0.7",
-    "babel": "^5.8.23"
+    "request": "^2.65.0"
   },
   "devDependencies": {
     "@springworks/test-harness": "1.2.0",

--- a/src/cli/record-deployment.js
+++ b/src/cli/record-deployment.js
@@ -1,0 +1,26 @@
+const program = require('commander');
+const deployment_notifier = require('../index');
+
+exports.run = function(process) {
+  program
+      .option('-N, --app-name <app name>', 'Application name')
+      .option('-P, --previous-deployment-tag <git tag>', 'Name of tag for previous deployment')
+      .option('-T, --deployment-tag <git tag>', 'Name of tag for latest deployment')
+      .option('-E, --environment <target environment>', 'The environment deployment was targeted at')
+      .parse(process.argv);
+
+  console.log('');
+  console.log('Deployment of %j --> %j in %j completed', program.appName, program.previousDeploymentTag, program.deploymentTag, program.environment);
+  console.log('');
+
+  const notifier = deployment_notifier.create(process.env);
+  notifier.recordDeployment(program.appName, program.previousDeploymentTag, program.deploymentTag, program.environment)
+      .then(() => {
+        console.log('Done!');
+        process.exit(0);
+      })
+      .catch(err => {
+        console.error('Error notifying about deployment', err);
+        process.exit(1);
+      });
+};

--- a/src/configurator.js
+++ b/src/configurator.js
@@ -1,11 +1,44 @@
-exports.create = env => {
-  if (!env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL || !env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME || !env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL) {
-    throw new Error('Missing environment variables to config');
-  }
+const input_validator = require('@springworks/input-validator');
+const joi = input_validator.joi;
 
+const env_vars_validation_schema = joi.object().required().keys({
+  NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL: joi.string().required(),
+  NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME: joi.string().required(),
+  NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL: joi.string().required(),
+  NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_URL: joi.string().required(),
+  NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_USERNAME: joi.string().required(),
+  NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_PASSWORD: joi.string().required(),
+});
+
+const internals = {};
+
+exports.create = env => {
+  const validated_env = internals.validateEnvVars(env);
   return {
-    slack_webhook_url: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL,
-    slack_username: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME,
-    slack_channel: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL,
+    slack: {
+      webhook_url: validated_env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL,
+      username: validated_env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME,
+      channel: validated_env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL,
+    },
+    webhook: {
+      url: validated_env.NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_URL,
+      basic_auth: {
+        username: validated_env.NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_USERNAME,
+        password: validated_env.NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_PASSWORD,
+      },
+    },
   };
+};
+
+
+internals.validateEnvVars = function(env_vars) {
+  const options_to_allow_excessive_env_vars = { stripUnknown: true };
+
+  try {
+    return input_validator.validateSchema(env_vars, env_vars_validation_schema, null, options_to_allow_excessive_env_vars);
+  }
+  catch (err) {
+    console.error('validateEnvVars failed: %j', err);
+    throw err;
+  }
 };

--- a/src/deployment-advisor.js
+++ b/src/deployment-advisor.js
@@ -9,7 +9,7 @@ exports.create = function(git_service, slack_notifier) {
 
 internals.suggestDeployment = function({ git_service, slack_notifier }, app_name, latest_tag_name, deployment_url) {
   return git_service
-      .getChangesSinceTag(latest_tag_name)
+      .getChangesBetweenTags(latest_tag_name)
       .then(changelog => {
         return git_service
             .getLatestAuthorName()

--- a/src/deployment-recorder.js
+++ b/src/deployment-recorder.js
@@ -1,0 +1,45 @@
+const internals = {};
+
+exports.create = function(git_service, slack_notifier, webhook_notifier) {
+  return {
+    recordDeployment: internals.recordDeployment.bind(null, { git_service, slack_notifier, webhook_notifier }),
+  };
+};
+
+internals.recordDeployment = function({ git_service, slack_notifier, webhook_notifier }, app_name, previous_tag_name, current_tag_name, target_environment) {
+  return git_service
+      .getChangesBetweenTags(previous_tag_name, current_tag_name)
+      .then(changelog => {
+        return Promise.all([
+          internals.sendSlackMessage(slack_notifier, app_name, previous_tag_name, current_tag_name, changelog, target_environment),
+          webhook_notifier.sendDeploymentMessage(app_name, current_tag_name, target_environment, changelog),
+        ]);
+      });
+};
+
+
+internals.sendSlackMessage = function(slack_notifier, app_name, previous_tag_name, current_tag_name, changelog, target_environment) {
+  const attachments = [internals.generateDeploymentSlackAttachment(current_tag_name, changelog)];
+  const message = `Deployed new version of *${app_name}* to ${target_environment}! :rocket:`;
+  return slack_notifier.sendDeploymentMessage(message, attachments);
+};
+
+
+internals.generateDeploymentSlackAttachment = function(current_tag_name, changelog) {
+  return {
+    fallback: changelog,
+    fields: [
+      {
+        title: `${current_tag_name}`,
+        value: changelog,
+        short: false,
+      },
+    ],
+  };
+};
+
+
+/* istanbul ignore else */
+if (process.env.NODE_ENV === 'test') {
+  exports.internals = internals;
+}

--- a/src/git/git-service.js
+++ b/src/git/git-service.js
@@ -3,24 +3,24 @@ const internals = {};
 
 exports.create = function(child_process) {
   return {
-    getChangesSinceTag: internals.getChangesSinceTag.bind(null, { child_process }),
+    getChangesBetweenTags: internals.getChangesBetweenTags.bind(null, { child_process }),
     getLatestAuthorName: internals.getLatestAuthorName.bind(null, { child_process }),
   };
 };
 
 
-internals.getChangesSinceTag = function({ child_process }, tag_name) {
+internals.getChangesBetweenTags = function({ child_process }, from_tag_name, to_tag_name = 'HEAD') {
   const git_command_args = [
     'log',
     '--pretty=format:"- %s"',
-    `${tag_name}..HEAD`,
+    `${from_tag_name}..${to_tag_name}`,
     '--no-merges',
     '--reverse',
   ];
   return internals
       .executeCommand(child_process, git_command_args)
       .catch(err => {
-        console.error('getChangesSinceTag failed: %j', err);
+        console.error('getChangesBetweenTags failed: %j', err);
         throw err;
       });
 };

--- a/src/http/webhook-notifier.js
+++ b/src/http/webhook-notifier.js
@@ -1,0 +1,72 @@
+const input_validator = require('@springworks/input-validator');
+const joi = input_validator.joi;
+
+const internals = {};
+
+
+exports.create = function(request, webhook_url, basic_auth) {
+  return {
+    sendDeploymentMessage: internals.sendDeploymentMessage.bind(null, { request, webhook_url, basic_auth }),
+  };
+};
+
+
+const send_deployment_message_params_schema = joi.object().required().keys({
+  app_name: joi.string().required(),
+  revision: joi.string().required(),
+  environment: joi.string().required(),
+  changelog: joi.string().required().allow(''),
+});
+
+internals.sendDeploymentMessage = function({ request, webhook_url, basic_auth }, app_name, revision, environment, changelog) {
+  return new Promise((resolve, reject) => {
+    const validated_params = input_validator.validateSchema({
+      app_name, revision, environment, changelog,
+    }, send_deployment_message_params_schema);
+
+    const req_body = internals.generateRequestBody(validated_params.app_name,
+        validated_params.revision,
+        validated_params.environment,
+        validated_params.changelog);
+
+    const req_opts = {
+      method: 'post',
+      url: webhook_url,
+      json: req_body,
+      auth: basic_auth,
+    };
+
+    internals.sendRequest(request, req_opts, (err, res) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      else if (res.statusCode >= 400) {
+        reject(new Error(`Failed to send deployment message to ${req_opts.url}, status code: ${res.statusCode}`));
+        return;
+      }
+      resolve();
+    });
+  });
+};
+
+
+internals.generateRequestBody = function(app_name, revision, environment, changelog) {
+  return {
+    application_name: app_name,
+    changes: changelog,
+    revision,
+    environment,
+  };
+};
+
+
+internals.sendRequest = function(request, req_opts, callback) {
+  request(req_opts, callback);
+};
+
+
+/* istanbul ignore else */
+if (process.env.NODE_ENV === 'test') {
+  exports.internals = internals;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,24 @@
 const child_process = require('child_process');
+const request = require('request');
 
 const deployment_advisor = require('./deployment-advisor');
+const deployment_recorder = require('./deployment-recorder');
 const git_service = require('./git/git-service');
 const slack_notifier = require('./slack/slack-notifier');
+const webhook_notifier = require('./http/webhook-notifier');
 const configurator = require('./configurator');
 
 exports.create = function(process_env) {
   const config = configurator.create(process_env);
   const git_service_instance = git_service.create(child_process);
-  const slack_notifier_instance = slack_notifier.create(config.slack_webhook_url,
-      config.slack_username,
-      config.slack_channel);
+  const slack_notifier_instance = slack_notifier.create(config.slack.webhook_url, config.slack.username, config.slack.channel);
+  const webhook_notifier_instance = webhook_notifier.create(request, config.webhook.url, config.webhook.basic_auth);
 
   const advisor = deployment_advisor.create(git_service_instance, slack_notifier_instance);
+  const recorder = deployment_recorder.create(git_service_instance, slack_notifier_instance, webhook_notifier_instance);
 
   return {
     suggestDeployment: advisor.suggestDeployment,
+    recordDeployment: recorder.recordDeployment,
   };
 };

--- a/test-util/dependency-helper.js
+++ b/test-util/dependency-helper.js
@@ -1,6 +1,6 @@
 exports.mockGitService = function() {
   return {
-    getChangesSinceTag() {
+    getChangesBetweenTags() {
     },
     getLatestAuthorName() {
     },
@@ -9,6 +9,14 @@ exports.mockGitService = function() {
 
 
 exports.mockSlackNotifier = function() {
+  return {
+    sendDeploymentMessage() {
+    },
+  };
+};
+
+
+exports.mockWebhookNotifier = function() {
   return {
     sendDeploymentMessage() {
     },

--- a/test-util/dependency-helper.js
+++ b/test-util/dependency-helper.js
@@ -1,0 +1,16 @@
+exports.mockGitService = function() {
+  return {
+    getChangesSinceTag() {
+    },
+    getLatestAuthorName() {
+    },
+  };
+};
+
+
+exports.mockSlackNotifier = function() {
+  return {
+    sendDeploymentMessage() {
+    },
+  };
+};

--- a/test/acceptance/index-test.js
+++ b/test/acceptance/index-test.js
@@ -8,6 +8,10 @@ describe(__filename, () => {
         NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL: 'http://hook.com',
         NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME: 'Mr Bot',
         NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL: '#deployments',
+        NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_URL: 'http://hook.com',
+        NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_USERNAME: 'secret-user',
+        NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_PASSWORD: 'secret-pass',
+        EXCESSIVE_VAR: 'should be ignored',
       },
     };
 
@@ -20,6 +24,7 @@ describe(__filename, () => {
     it('should export public functions on create()', () => {
       index.create(mock_process.env).should.have.keys([
         'suggestDeployment',
+        'recordDeployment',
       ]);
     });
 

--- a/test/unit/configurator-test.js
+++ b/test/unit/configurator-test.js
@@ -10,36 +10,49 @@ describe(__filename, () => {
       env = internals.createValidEnvVars();
     });
 
-    describe('with all env vars provided', () => {
+    describe('env vars', () => {
 
-      it('should return configuration', () => {
-        const config = configurator.create(env);
-        config.should.eql({
-          slack_webhook_url: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL,
-          slack_username: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME,
-          slack_channel: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL,
+      describe('with all vars provided', () => {
+
+        it('should return configuration', () => {
+          const config = configurator.create(env);
+          config.should.eql({
+            slack: {
+              webhook_url: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL,
+              username: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME,
+              channel: env.NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL,
+            },
+            webhook: {
+              url: env.NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_URL,
+              basic_auth: {
+                username: env.NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_USERNAME,
+                password: env.NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_PASSWORD,
+              },
+            },
+          });
         });
+
       });
 
-    });
+      describe('missing required variable', () => {
+        const required_variables = [
+          'NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL',
+          'NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME',
+          'NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL',
+        ];
 
-    describe('missing required variable', () => {
-      const required_variables = [
-        'NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL',
-        'NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME',
-        'NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL',
-      ];
+        required_variables.forEach(param => {
 
-      required_variables.forEach(param => {
+          describe(`missing ${param}`, () => {
 
-        describe(`missing ${param}`, () => {
+            beforeEach(() => {
+              delete env[param];
+            });
 
-          beforeEach(() => {
-            delete env[param];
-          });
+            it('should fail with error', () => {
+              (() => configurator.create(env)).should.throw();
+            });
 
-          it('should fail with error', () => {
-            (() => configurator.create(env)).should.throw();
           });
 
         });
@@ -52,11 +65,15 @@ describe(__filename, () => {
 
 });
 
+
 internals.createValidEnvVars = function() {
   return {
     NODE_DEPLOYMENT_NOTIFIER_SLACK_WEBHOOK_URL: 'http://hook.com',
     NODE_DEPLOYMENT_NOTIFIER_SLACK_USERNAME: 'Mr Bot',
     NODE_DEPLOYMENT_NOTIFIER_SLACK_CHANNEL: '#deployments',
-    OTHER_VAR: 'should be ignored',
+    NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_URL: 'http://hook.com',
+    NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_USERNAME: 'secret-user',
+    NODE_DEPLOYMENT_NOTIFIER_WEBHOOK_BASIC_AUTH_PASSWORD: 'secret-pass',
+    EXCESSIVE_VAR: 'should be ignored',
   };
 };

--- a/test/unit/deployment-advisor-test.js
+++ b/test/unit/deployment-advisor-test.js
@@ -1,4 +1,5 @@
 const deployment_advisor = require('../../src/deployment-advisor');
+const dependency_helper = require('../../test-util/dependency-helper');
 
 describe(__filename, function() {
   let sinon_sandbox;
@@ -15,16 +16,8 @@ describe(__filename, function() {
   });
 
   beforeEach(function mockDependencies() {
-    mock_git_service = {
-      getChangesSinceTag() {
-      },
-      getLatestAuthorName() {
-      },
-    };
-    mock_slack_notifier = {
-      sendDeploymentMessage() {
-      },
-    };
+    mock_git_service = dependency_helper.mockGitService();
+    mock_slack_notifier = dependency_helper.mockSlackNotifier();
 
     dependencies = { git_service: mock_git_service, slack_notifier: mock_slack_notifier };
   });

--- a/test/unit/deployment-advisor-test.js
+++ b/test/unit/deployment-advisor-test.js
@@ -44,7 +44,7 @@ describe(__filename, function() {
         let send_deployment_message_stub;
 
         beforeEach(function mockChangelog() {
-          sinon_sandbox.stub(mock_git_service, 'getChangesSinceTag').returns(Promise.resolve(changelog));
+          sinon_sandbox.stub(mock_git_service, 'getChangesBetweenTags').returns(Promise.resolve(changelog));
         });
 
         beforeEach(function mockLastAuthor() {
@@ -90,8 +90,8 @@ describe(__filename, function() {
       describe('when git_service fails', () => {
 
         beforeEach(function mockChangelog() {
-          const err = new Error('Mocked getChangesSinceTag error');
-          sinon_sandbox.stub(mock_git_service, 'getChangesSinceTag').returns(Promise.reject(err));
+          const err = new Error('Mocked getChangesBetweenTags error');
+          sinon_sandbox.stub(mock_git_service, 'getChangesBetweenTags').returns(Promise.reject(err));
         });
 
         it('should reject promise', () => {
@@ -103,7 +103,7 @@ describe(__filename, function() {
       describe('when only slack_notifier fails', () => {
 
         beforeEach(function mockChangelog() {
-          sinon_sandbox.stub(mock_git_service, 'getChangesSinceTag').returns(Promise.resolve('These are all the changes'));
+          sinon_sandbox.stub(mock_git_service, 'getChangesBetweenTags').returns(Promise.resolve('These are all the changes'));
         });
 
         beforeEach(function mockLastAuthor() {
@@ -111,7 +111,7 @@ describe(__filename, function() {
         });
 
         beforeEach(function mockFailedSendMessage() {
-          const err = new Error('Mocked getChangesSinceTag error');
+          const err = new Error('Mocked getChangesBetweenTags error');
           sinon_sandbox.stub(mock_slack_notifier, 'sendDeploymentMessage').returns(Promise.reject(err));
         });
 

--- a/test/unit/deployment-recorder-test.js
+++ b/test/unit/deployment-recorder-test.js
@@ -1,0 +1,112 @@
+const deployment_recorder = require('../../src/deployment-recorder');
+const dependency_helper = require('../../test-util/dependency-helper');
+
+describe(__filename, function() {
+  let sinon_sandbox;
+  let mock_git_service;
+  let mock_slack_notifier;
+  let mock_webhook_notifier;
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(() => {
+    mock_git_service = dependency_helper.mockGitService();
+    mock_slack_notifier = dependency_helper.mockSlackNotifier();
+    mock_webhook_notifier = dependency_helper.mockWebhookNotifier();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('create', () => {
+
+    it('should return object with public functions', () => {
+      const recorder = deployment_recorder.create(mock_git_service, mock_slack_notifier);
+      recorder.should.have.keys(['recordDeployment']);
+    });
+
+  });
+
+  describe('internals.recordDeployment', () => {
+
+    describe('with valid dependencies', () => {
+      const changelog = 'I changed this';
+      const target_environment = 'production';
+      let dependencies;
+      let get_changes_since_tag_stub;
+      let send_slack_deployment_message_stub;
+      let send_webhook_deployment_message_stub;
+
+      beforeEach(() => {
+        dependencies = {
+          git_service: mock_git_service,
+          slack_notifier: mock_slack_notifier,
+          webhook_notifier: mock_webhook_notifier,
+        };
+      });
+
+      beforeEach(() => {
+        get_changes_since_tag_stub = sinon_sandbox.stub(mock_git_service, 'getChangesBetweenTags').returns(Promise.resolve(changelog));
+      });
+
+      beforeEach(function mockSendSlackMessage() {
+        send_slack_deployment_message_stub = sinon_sandbox.stub(mock_slack_notifier, 'sendDeploymentMessage').returns(Promise.resolve(null));
+      });
+
+      beforeEach(function mockSendWebhookMessage() {
+        send_webhook_deployment_message_stub = sinon_sandbox.stub(mock_webhook_notifier, 'sendDeploymentMessage').returns(Promise.resolve(null));
+      });
+
+      describe('with valid app_name, previous_tag_name, current_tag_name', () => {
+        const app_name = 'my-app';
+        const previous_tag_name = 'v1.0.0';
+        const current_tag_name = 'v1.0.1';
+
+        it('should get version diff changelog from git service', () => {
+          return deployment_recorder.internals.recordDeployment(dependencies, app_name, previous_tag_name, current_tag_name, target_environment)
+              .then(() => {
+                get_changes_since_tag_stub.should.have.callCount(1);
+
+                const get_changes_args = get_changes_since_tag_stub.getCall(0).args;
+                const from_tag = get_changes_args[0];
+                from_tag.should.eql(previous_tag_name);
+
+                const to_tag = get_changes_args[1];
+                to_tag.should.eql(current_tag_name);
+              });
+        });
+
+        it('should send message to slack notifier', () => {
+          return deployment_recorder.internals.recordDeployment(dependencies, app_name, previous_tag_name, current_tag_name, target_environment)
+              .then(() => {
+                const message_arg = send_slack_deployment_message_stub.getCall(0).args[0];
+                message_arg.should.eql(`Deployed new version of *${app_name}* to ${target_environment}! :rocket:`);
+              });
+        });
+
+        it('should send message to webhook', () => {
+          return deployment_recorder.internals.recordDeployment(dependencies, app_name, previous_tag_name, current_tag_name, target_environment)
+              .then(() => {
+                const call_args = send_webhook_deployment_message_stub.getCall(0).args;
+                const app_name_arg = call_args[0];
+                const revision_arg = call_args[1];
+                const environment_arg = call_args[2];
+                const changelog_arg = call_args[3];
+
+                app_name_arg.should.eql(app_name);
+                revision_arg.should.eql(current_tag_name);
+                environment_arg.should.eql(target_environment);
+                changelog_arg.should.eql(changelog);
+              });
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/git/git-service-test.js
+++ b/test/unit/git/git-service-test.js
@@ -19,7 +19,7 @@ describe(__filename, function() {
       it('should return object with public functions', () => {
         const instance = git_service.create(mock_child_process);
         instance.should.have.keys([
-          'getChangesSinceTag',
+          'getChangesBetweenTags',
           'getLatestAuthorName',
         ]);
       });
@@ -28,10 +28,10 @@ describe(__filename, function() {
 
   });
 
-  describe('internals.getChangesSinceTag', () => {
+  describe('internals.getChangesBetweenTags', () => {
 
     describe('with child_process, tag_name', () => {
-      const tag_name = 'the-tag';
+      const from_tag_name = 'the-tag';
       let execute_command_stub;
 
       describe('when exec() succeeds', () => {
@@ -42,18 +42,18 @@ describe(__filename, function() {
         });
 
         it('should resolve promise once done', () => {
-          return git_service.internals.getChangesSinceTag({ child_process: mock_child_process }, tag_name).should.be.fulfilledWith(result_str);
+          return git_service.internals.getChangesBetweenTags({ child_process: mock_child_process }, from_tag_name).should.be.fulfilledWith(result_str);
         });
 
-        it('should invoke exec() with the correct command', () => {
+        it('should invoke exec() using HEAD as default to_tag_name', () => {
           const expected_command_args = [
             'log',
             '--pretty=format:"- %s"',
-            `${tag_name}..HEAD`,
+            `${from_tag_name}..HEAD`,
             '--no-merges',
             '--reverse',
           ];
-          return git_service.internals.getChangesSinceTag({ child_process: mock_child_process }, tag_name)
+          return git_service.internals.getChangesBetweenTags({ child_process: mock_child_process }, from_tag_name)
               .then(() => {
                 execute_command_stub.should.have.callCount(1);
 
@@ -72,7 +72,40 @@ describe(__filename, function() {
         });
 
         it('should reject promise', () => {
-          return git_service.internals.getChangesSinceTag({ child_process: mock_child_process }, tag_name).should.be.rejected();
+          return git_service.internals.getChangesBetweenTags({ child_process: mock_child_process }, from_tag_name).should.be.rejected();
+        });
+
+      });
+
+    });
+
+    describe('with child_process, from_tag_name, to_tag_name', () => {
+      const from_tag_name = 'from-the-tag';
+      const to_tag_name = 'to-the-tag';
+      let execute_command_stub;
+
+      describe('when exec() succeeds', () => {
+        const result_str = 'This is the change';
+
+        beforeEach(function mockSuccessfulCommand() {
+          execute_command_stub = sinon_sandbox.stub(git_service.internals, 'executeCommand').returns(Promise.resolve(result_str));
+        });
+
+        it('should invoke exec() with the correct command', () => {
+          const expected_command_args = [
+            'log',
+            '--pretty=format:"- %s"',
+            `${from_tag_name}..${to_tag_name}`,
+            '--no-merges',
+            '--reverse',
+          ];
+          return git_service.internals.getChangesBetweenTags({ child_process: mock_child_process }, from_tag_name, to_tag_name)
+              .then(() => {
+                execute_command_stub.should.have.callCount(1);
+
+                const command_arg = execute_command_stub.getCall(0).args[1];
+                command_arg.should.eql(expected_command_args);
+              });
         });
 
       });
@@ -82,6 +115,7 @@ describe(__filename, function() {
   });
 
   describe('internals.getLatestAuthorName', () => {
+
     describe('with child_process, tag_name', () => {
       const tag_name = 'the-tag';
       let execute_command_stub;

--- a/test/unit/http/webhook-notifier-test.js
+++ b/test/unit/http/webhook-notifier-test.js
@@ -1,0 +1,172 @@
+const webhook_notifier = require('../../../src/http/webhook-notifier');
+
+describe(__filename, () => {
+  const webhook_url = 'https://internet.com';
+  const basic_auth = {
+    username: 'user',
+    password: 'pass',
+  };
+  let sinon_sandbox;
+  let mock_request_module;
+
+  beforeEach(() => {
+    mock_request_module = (opts, callback) => {
+      const http_res = { statusCode: 200 };
+      const res_body = {};
+      callback(null, http_res, res_body);
+    };
+  });
+
+  beforeEach(() => {
+    sinon_sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sinon_sandbox.restore();
+  });
+
+  describe('create', () => {
+
+    describe('with webhook_url, basic_auth', () => {
+
+
+      it('should return object with public functions', () => {
+        const service = webhook_notifier.create(mock_request_module, webhook_url, basic_auth);
+        service.should.have.keys([
+          'sendDeploymentMessage',
+        ]);
+      });
+
+    });
+
+    describe('with webhook_url but no basic_auth', () => {
+
+      it('should return object with public functions', () => {
+        const service = webhook_notifier.create(mock_request_module, webhook_url, basic_auth);
+        service.should.have.keys([
+          'sendDeploymentMessage',
+        ]);
+      });
+
+    });
+
+  });
+
+  describe('internals.sendDeploymentMessage', () => {
+    let dependencies;
+
+    beforeEach(() => {
+      dependencies = { request: mock_request_module, webhook_url, basic_auth };
+    });
+
+    describe('with valid params', () => {
+      const app_name = 'my-app';
+      const revision = 'v1.0.1';
+      const environment = 'production';
+      const changelog = '- This\n- That';
+
+      describe('when request succeeds', () => {
+        let send_request_stub;
+
+        beforeEach(function mockSendRequest() {
+          const mock_response = {};
+          const mock_body = {};
+          send_request_stub = sinon_sandbox.stub(webhook_notifier.internals, 'sendRequest').callsArgWithAsync(2, null, mock_response, mock_body);
+        });
+
+        it('should POST to webhook URL with proper JSON body', () => {
+          return webhook_notifier.internals
+              .sendDeploymentMessage(dependencies, app_name, revision, environment, changelog)
+              .then(() => {
+                send_request_stub.should.have.callCount(1);
+
+                const call_args = send_request_stub.getCall(0).args;
+                call_args[1].should.eql({
+                  method: 'post',
+                  url: webhook_url,
+                  auth: basic_auth,
+                  json: {
+                    application_name: app_name,
+                    changes: changelog,
+                    revision,
+                    environment,
+                  },
+                });
+              });
+        });
+
+        describe('having empty changelog', () => {
+          const empty_changelog = '';
+
+          it('should resolve promise', () => {
+            return webhook_notifier.internals.sendDeploymentMessage(dependencies, app_name, revision, environment, empty_changelog);
+          });
+
+        });
+
+      });
+
+      describe('when request fails with error status code', () => {
+
+        beforeEach(function mockFailedSendRequest() {
+          const mock_response = { statusCode: 404 };
+          const mock_body = {};
+          sinon_sandbox.stub(webhook_notifier.internals, 'sendRequest').callsArgWithAsync(2, null, mock_response, mock_body);
+        });
+
+        it('should reject with error', () => {
+          return webhook_notifier.internals.sendDeploymentMessage(dependencies, app_name, revision, environment, changelog)
+              .should.be.rejectedWith(/Failed to send deployment message/);
+        });
+
+      });
+
+      describe('when request fails with error', () => {
+
+        beforeEach(function mockFailedSendRequest() {
+          const mock_err = new Error('Mocked timeout');
+          sinon_sandbox.stub(webhook_notifier.internals, 'sendRequest').callsArgWithAsync(2, mock_err, null, null);
+        });
+
+        it('should reject with error', () => {
+          return webhook_notifier.internals.sendDeploymentMessage(dependencies, app_name, revision, environment, changelog)
+              .should.be.rejectedWith(/Mocked timeout/);
+        });
+
+      });
+
+    });
+
+    describe('with invalid params (missing all)', () => {
+
+      it('should fail with validation error', () => {
+        return webhook_notifier.internals.sendDeploymentMessage(dependencies).should.be.rejectedWith('Validation Failed');
+      });
+
+    });
+
+  });
+
+  describe('internals.generateRequestBody', () => {
+
+    describe('with valid params', () => {
+      const app_name = 'my-app';
+      const revision = 'v1.0.1';
+      const environment = 'production';
+      const changelog = '- This\n- That';
+
+      it('should return object using all properties', () => {
+        const req_body = webhook_notifier.internals.generateRequestBody(app_name, revision, environment, changelog);
+        req_body.should.eql({
+          application_name: app_name,
+          changes: changelog,
+          revision,
+          environment,
+        });
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
**NOTE:** Since only use case is currently both webhook and Slack, all environment variables are required. No need to make it more generic at this point, at least.

---
### Record deployment

Sends message after a deployment has completed, to both Slack webhook and HTTP webhook.

Includes changes in the new version.

**Usage**

```
  Usage: deployment-completed [options]

  Options:

    -h, --help                               output usage information
    -N, --app-name <app name>                Application name
    -P, --previous-deployment-tag <git tag>  Name of tag for previous deployment
    -T, --deployment-tag <git tag>           Name of tag for latest deployment
    -E, --environment <target environment>   The environment deployment was targeted at
```
