### PR TITLE
Use :package: emoji for deployment suggestion

### DIFF
--- a/src/deployment-advisor.js
+++ b/src/deployment-advisor.js
@@ -16,7 +16,7 @@ internals.suggestDeployment = function({ git_service, slack_notifier }, app_name
               .getLatestAuthorName()
               .then(last_author => {
                 const attachments = [internals.generateDeploymentSuggestionSlackAttachment(changelog, latest_tag_name)];
-                const message = `Hey, *${last_author}*. Might be a good time to deploy *${app_name}*.\n:rocket: ${deployment_url}`;
+                const message = `Hey, *${last_author}*. Might be a good time to deploy *${app_name}*.\n:package: ${deployment_url}`;
                 return slack_notifier.sendDeploymentMessage(message, attachments);
               });
         }

--- a/test/unit/deployment-advisor-test.js
+++ b/test/unit/deployment-advisor-test.js
@@ -73,7 +73,7 @@ describe(__filename, function() {
                   const message_arg = send_deployment_message_stub.getCall(0).args[0];
                   message_arg.should.eql(`Hey, *${author_name}*. Might be a good time to deploy *${app_name}*.` +
                                          '\n' +
-                                         `:rocket: ${deployment_url}`);
+                                         `:package: ${deployment_url}`);
                 });
           });
 


### PR DESCRIPTION
Makes sense not to use :rocket: in both suggestion and notification, since it makes it harder to understand what happened.
