### PR TITLE
Feat: make possible to provide message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - '4'
-  - '6'
+  - '8'
 notifications:
   email: false
   slack:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Includes changes in the new version.
 
     -h, --help                               output usage information
     -N, --app-name <app name>                Application name
+    -M, --message <release notes>            Release notes (required unless providing tags)
     -P, --previous-deployment-tag <git tag>  Name of tag for previous deployment
     -T, --deployment-tag <git tag>           Name of tag for latest deployment
     -E, --environment <target environment>   The environment deployment was targeted at

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     }
   },
   "engines": {
-    "node": ">=4",
-    "npm": ">=2.7"
+    "node": ">=8",
+    "npm": ">=5"
   },
   "repository": {
     "type": "git",

--- a/src/cli/record-deployment.js
+++ b/src/cli/record-deployment.js
@@ -4,17 +4,18 @@ const deployment_notifier = require('../index');
 exports.run = function(process) {
   program
       .option('-N, --app-name <app name>', 'Application name')
+      .option('-M, --message <release notes>', 'Release notes (required unless providing -P)')
       .option('-P, --previous-deployment-tag <git tag>', 'Name of tag for previous deployment')
       .option('-T, --deployment-tag <git tag>', 'Name of tag for latest deployment')
       .option('-E, --environment <target environment>', 'The environment deployment was targeted at')
       .parse(process.argv);
 
   console.log('');
-  console.log('Deployment of %j --> %j in %j completed', program.appName, program.previousDeploymentTag, program.deploymentTag, program.environment);
+  console.log('Deployment of %s to %s completed', program.appName, program.environment);
   console.log('');
 
   const notifier = deployment_notifier.create(process.env);
-  notifier.recordDeployment(program.appName, program.previousDeploymentTag, program.deploymentTag, program.environment)
+  notifier.recordDeployment(program.appName, program.previousDeploymentTag, program.deploymentTag, program.message, program.environment)
       .then(() => {
         console.log('Done!');
         process.exit(0);

--- a/src/deployment-recorder.js
+++ b/src/deployment-recorder.js
@@ -6,15 +6,18 @@ exports.create = function(git_service, slack_notifier, webhook_notifier) {
   };
 };
 
-internals.recordDeployment = function({ git_service, slack_notifier, webhook_notifier }, app_name, previous_tag_name, current_tag_name, target_environment) {
-  return git_service
-      .getChangesBetweenTags(previous_tag_name, current_tag_name)
-      .then(changelog => {
-        return Promise.all([
-          internals.sendSlackMessage(slack_notifier, app_name, previous_tag_name, current_tag_name, changelog, target_environment),
-          webhook_notifier.sendDeploymentMessage(app_name, current_tag_name, target_environment, changelog),
-        ]);
-      });
+internals.recordDeployment = async function({ git_service, slack_notifier, webhook_notifier }, app_name, previous_tag_name, current_tag_name, message, target_environment) {
+  let changelog;
+  if (message) {
+    changelog = message;
+  }
+  else {
+    changelog = await git_service.getChangesBetweenTags(previous_tag_name, current_tag_name);
+  }
+  return Promise.all([
+    internals.sendSlackMessage(slack_notifier, app_name, previous_tag_name, current_tag_name, changelog, target_environment),
+    webhook_notifier.sendDeploymentMessage(app_name, current_tag_name, target_environment, changelog),
+  ]);
 };
 
 


### PR DESCRIPTION
Useful when not having two tags to diff between.

---

🎓 We might want to rewrite this quite a lot, but this is a quick win to start recording deployments in a better way (e.g. for iOS and other projects where previous setup doesn't work).